### PR TITLE
Add security descriptor read command

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,18 @@ func main() {
 			Action:    samba.MD5,
 		},
 		{
+			Name:      "sd",
+			Usage:     "display the security descriptor of a file in string format",
+			UsageText: "carnival sd [smburl]",
+			Action:    samba.Sd,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "debug",
+					Usage: "when set, will output the security descriptor indented",
+				},
+			},
+		},
+		{
 			Name:      "shares",
 			Usage:     "list the publicly visible shares",
 			UsageText: "carnival shares [smburl]",

--- a/pkg/samba/sd.go
+++ b/pkg/samba/sd.go
@@ -1,0 +1,58 @@
+package samba
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cloudsoda/go-smb2"
+	"github.com/urfave/cli/v2"
+)
+
+func Sd(ctx *cli.Context) error {
+	u, err := urlFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if u.Share == "" {
+		return errors.New("no share name specified")
+	}
+
+	session, err := connect(u, ctx.String(FlagDomain))
+	if err != nil {
+		return fmt.Errorf("connect failed: %v", err)
+	}
+	defer session.Logoff()
+
+	share, err := session.Mount(u.Share, parseOptions(ctx)...)
+	if err != nil {
+		return fmt.Errorf("mounting '%s': %v", u.Share, err)
+	}
+	defer share.Umount()
+
+	f, err := share.Open(u.Path)
+	if err != nil {
+		return fmt.Errorf("open source file: %v", err)
+	}
+	defer f.Close()
+
+	// try to read all security descriptors
+	sd, err := f.SecurityInfo(smb2.OwnerSecurityInformation | smb2.GroupSecurityInformation | smb2.DACLSecurityInformation | smb2.SACLSecurityInformation)
+	if err != nil {
+		// try to read all but SACL
+		sd, err = f.SecurityInfo(smb2.OwnerSecurityInformation | smb2.GroupSecurityInformation | smb2.DACLSecurityInformation)
+		if err != nil {
+			return fmt.Errorf("read security descriptors: %v", err)
+		}
+	}
+
+	var sdStr string
+	if ctx.Bool("debug") {
+		sdStr = sd.StringIndent(0)
+	} else {
+		sdStr = sd.String()
+	}
+
+	fmt.Println(sdStr)
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a new command `sd` for reading security descriptor from a file or directory, the command will print the security descriptor in its string representation (SDDL)

Usage:

```sh
./carnival -u <username> sd [--pretty] smb://host:port/share/path/to/file.txt
```

note the `--pretty` flag prints the security descriptor indented so it is easier for a human to read it